### PR TITLE
chore: prepare release v0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smooth-auto-scroll",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smooth-auto-scroll",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smooth-auto-scroll",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Smooth auto-scroll React hook and component for ultra-smooth motion at any speed.",
   "license": "MIT",
   "author": "Marc Derhammer <marc.derhammer@gmail.com>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "lib": ["ES2020", "DOM"],
     "module": "ESNext",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,8 +9,10 @@ export default defineConfig({
   format: ["esm", "cjs"],
   target: "es2020",
   minify: false,
-  external: ["react", "react-dom"],
+  external: ["react", "react-dom", "react/jsx-runtime"],
   esbuildOptions(options) {
-    options.jsx = "automatic";
+    options.jsx = "transform";
+    options.jsxFactory = "React.createElement";
+    options.jsxFragment = "React.Fragment";
   },
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   format: ["esm", "cjs"],
   target: "es2020",
   minify: false,
-  external: ["react", "react-dom", "react/jsx-runtime"],
+  external: ["react", "react-dom"],
   esbuildOptions(options) {
     options.jsx = "transform";
     options.jsxFactory = "React.createElement";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: false,
   external: ["react", "react-dom"],
   esbuildOptions(options) {
-    options.jsx = "preserve";
+    options.jsx = "transform";
     options.jsxFactory = "React.createElement";
     options.jsxFragment = "React.Fragment";
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: false,
   external: ["react", "react-dom"],
   esbuildOptions(options) {
-    options.jsx = "transform";
+    options.jsx = "preserve";
     options.jsxFactory = "React.createElement";
     options.jsxFragment = "React.Fragment";
   },


### PR DESCRIPTION
- Fix ESM import issues with React jsx-runtime
- Use classic JSX transform (React.createElement) instead of jsx-runtime
- Make React external to prevent bundling conflicts
- Configure tsconfig.json and tsup.config.ts for classic JSX
- Resolve 'Cannot find module react/jsx-runtime' errors completely